### PR TITLE
fix(www-authenticate in challenge response): Should always return wit…

### DIFF
--- a/lib/unauthorized.js
+++ b/lib/unauthorized.js
@@ -15,11 +15,11 @@ module.exports = function(app, config, logger) {
 
 function addWwwAuthenticateHeaders(req, res, domain, clientId, resourceServer, realm) {
   var v1WwwAuthenticateHeader = util.format('Bearer realm="%s", scope="client_id=%s service=%s"',
-    domain, clientId, req.protocol + "://" + req.hostname + req.baseUrl);
+    domain, clientId, "https://" + req.hostname + req.baseUrl);
 
   if (resourceServer) {
     var v2WwwAuthenticateHeader = util.format('Bearer realm="%s", authorization_uri="https://%s/oauth/token"', realm, domain);
-    return res.header('WWW-Authenticate', [v1WwwAuthenticateHeader, v2WwwAuthenticateHeader]);
+    return res.header('WWW-Authenticate', [v2WwwAuthenticateHeader, v1WwwAuthenticateHeader]);
   }
   res.header('WWW-Authenticate', v1WwwAuthenticateHeader);
 }

--- a/test/auth0verification.legacy.test.js
+++ b/test/auth0verification.legacy.test.js
@@ -79,8 +79,7 @@ describe('Verify auth0 application functions with legacy config.', function () {
       expect(helper.finishedRequest.user).to.be.undefined;
       expect(helper.finishedResponse._headers['www-authenticate']).to.include(
         'Bearer realm="' + domain + '", scope="client_id=' + clientId +
-        ' service=' + helper.finishedRequest.protocol +
-        '://' + helper.finishedRequest.hostname + helper.finishedRequest.baseUrl + '"');
+        ' service=https://' + helper.finishedRequest.hostname + helper.finishedRequest.baseUrl + '"');
     });
   });
 
@@ -104,8 +103,7 @@ describe('Verify auth0 application functions with legacy config.', function () {
       expect(helper.finishedRequest.user).to.be.undefined;
       expect(helper.finishedResponse._headers['www-authenticate']).to.include(
         'Bearer realm="' + domain + '", scope="client_id=' + clientId +
-        ' service=' + helper.finishedRequest.protocol +
-        '://' + helper.finishedRequest.hostname + helper.finishedRequest.baseUrl + '"');
+        ' service=https://' + helper.finishedRequest.hostname + helper.finishedRequest.baseUrl + '"');
       expect(helper.finishedResponse._headers['www-authenticate']).to.include(
         'Bearer realm="' + realm + '", authorization_uri="https://' + domain + '/oauth/token"');
     });

--- a/test/auth0verification.test.js
+++ b/test/auth0verification.test.js
@@ -72,8 +72,7 @@ describe('Verify auth0 application functions.', function () {
       expect(helper.finishedRequest.user).to.be.undefined;
       expect(helper.finishedResponse._headers['www-authenticate']).to.include(
         'Bearer realm="' + domain + '", scope="client_id=' + clientId +
-        ' service=' + helper.finishedRequest.protocol +
-        '://' + helper.finishedRequest.hostname + helper.finishedRequest.baseUrl + '"');
+        ' service=https://' + helper.finishedRequest.hostname + helper.finishedRequest.baseUrl + '"');
     });
   });
 
@@ -97,8 +96,7 @@ describe('Verify auth0 application functions.', function () {
       expect(helper.finishedRequest.user).to.be.undefined;
       expect(helper.finishedResponse._headers['www-authenticate']).to.include(
         'Bearer realm="' + domain + '", scope="client_id=' + clientId +
-        ' service=' + helper.finishedRequest.protocol +
-        '://' + helper.finishedRequest.hostname + helper.finishedRequest.baseUrl + '"');
+        ' service=https://' + helper.finishedRequest.hostname + helper.finishedRequest.baseUrl + '"');
       expect(helper.finishedResponse._headers['www-authenticate']).to.include(
         'Bearer realm="' + realm + '", authorization_uri="https://' + domain + '/oauth/token"');
     });


### PR DESCRIPTION
Should always return with https for service url and prioritize v2 over v1 in challenge response, if v2 is available